### PR TITLE
Update issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Easily see all the related values across your entire JSON document for a specifi
 
 ## Bugs and Feature Requests
 
-Have a bug or a feature request? Feel free to [open a new issue](/issues).
+Have a bug or a feature request? Feel free to [open a new issue](https://github.com/jsonhero-io/jsonhero-web/issues).
 
 You can also join our [Discord channel](https://discord.gg/ZQq6Had5nP) to hang out and discuss anything you'd like.
 


### PR DESCRIPTION
It seems just using`/issues` doesn't take the user to the issues page unless they are the repo creator? I went ahead and updated the link :) 

**Before:** 
![before](https://user-images.githubusercontent.com/32559031/164874050-f914e49e-e333-44e5-850a-4562d5873417.gif)



**After**:
![after](https://user-images.githubusercontent.com/32559031/164874102-e910df80-a4de-453a-a896-dab0506c9a4f.gif)
 