### PR TITLE
Create docker file and docker build push CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,45 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@main
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@master
+        with:
+          images: ${{ secrets.DOCKER_HUB_USERNAME }}/jsonhero-web
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Login to Docker Hub
+        uses: docker/login-action@master
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@master
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine
+RUN apk update
+
+WORKDIR /app
+COPY . .
+
+RUN echo "SESSION_SECRET=abc123" >> .env
+
+RUN npm install
+RUN npm run build
+
+EXPOSE 8787
+ENTRYPOINT ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -122,7 +122,33 @@ Have a bug or a feature request? Feel free to [open a new issue](https://github.
 
 You can also join our [Discord channel](https://discord.gg/ZQq6Had5nP) to hang out and discuss anything you'd like.
 
-## Developing
+## Developing and Deployment
+
+You could choose to deploy this service locally, either directly or by docker.
+
+## Docker
+
+You could pull prebuilt image from Docker Hub or build your own image locally.
+
+### Pull image and run 
+
+```bash
+# Pull the latest image from Docker Hub
+docker pull jsonhero_docker_hub_username/jsonhero-web:latest
+# Run the container, then visit http://localhost:8787
+docker run -it -d --name jsonhero_web -p 8787:8787 jsonhero_docker_hub_username/jsonhero-web:latest
+```
+
+### Build your own image locally
+
+```bash
+# Build your own image locally
+docker build . -t yourname/jsonhero-web:localdev
+# Run the container, then visit http://localhost:8787
+docker run -it -d --name jsonhero_web_dev -p 8787:8787 yourname/jsonhero-web:localdev
+```
+
+## Directly
 
 To run locally, first clone the repo and install the dependencies:
 


### PR DESCRIPTION
### Why docker?

Make it easier to deploy and debug. Since everyone can pull the same image from Docker Hub and the npm dependencies would be handled well in the building stage of docker image. Also this makes it easier to deploy for the machines that have docker but no node.js environment.


### Discussion

What is the purpose of setting `SESSION_SECRET=abc123`, should this be different for every deployment? If so, maybe we should set this SESSION_SECRET through a environment variable in docker?

### TODO before merge

- [ ] Create Docker Hub account for this organization
- [ ] Fill in the GitHub action secretes
- [ ] Create the Docker Hub repo named `jsonhero-web` or anything you like
- [ ] Update the repo names in README.md <https://github.com/henryclw/jsonhero-web/blob/1ec0a38a4f2aa22d659258c383119aa035ffb15c/README.md?plain=1#L144>

### TODO after merge

- [ ] Check the actions, are they working as expected
- [ ] Check your Docker Hub account, are the newly pushed images as expected
- [ ] Pull one of the image and try to run it locally

Any suggestions are welcomed!