### PR TITLE
Change search bar shortcut key

### DIFF
--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -16,7 +16,7 @@ export function SearchBar() {
   const searchApi = useJsonSearchApi();
 
   useHotkeys(
-    "cmd+k",
+    "shift+s",
     (e) => {
       e.preventDefault();
       setIsOpen(true);
@@ -37,10 +37,10 @@ export function SearchBar() {
           </div>
           <div className="flex items-center gap-1 pr-1">
             <ShortcutIcon className="w-4 h-4 text-sm bg-slate-200 transition group-hover:bg-slate-100 dark:bg-slate-700 dark:group-hover:bg-slate-600">
-              ⌘
+              ⇧
             </ShortcutIcon>
             <ShortcutIcon className="w-4 h-4 text-sm bg-slate-200 transition group-hover:bg-slate-100 dark:bg-slate-700 dark:group-hover:bg-slate-600">
-              K
+              S
             </ShortcutIcon>
           </div>
         </div>


### PR DESCRIPTION
The current shortcut key is `cmd+k` however this collides with google's search shortcut key resulting in a poor user experience.

![image](https://user-images.githubusercontent.com/23068029/166669646-3c198377-e49c-4455-a16b-f813db0bf2dd.png)

My solution is to change the combination to `shift+s` which is more accessible and does not collide with any other shortcut.