### PR TITLE
fixed error due to issue with server sided preview generation

### DIFF
--- a/app/components/Preview/Types/PreviewUri.tsx
+++ b/app/components/Preview/Types/PreviewUri.tsx
@@ -23,7 +23,15 @@ export function PreviewUri(props: PreviewUriProps) {
     <div>
       {previewFetcher.type === "done" ? (
         <>
-          {"error" in previewFetcher.data ? (
+          {typeof previewFetcher.data == "string" ? (
+            <PreviewBox>
+              <Body>
+                <span
+                  dangerouslySetInnerHTML={{ __html: previewFetcher.data }}
+                ></span>
+              </Body>
+            </PreviewBox>
+          ) : "error" in previewFetcher.data ? (
             <PreviewBox>
               <Body>{previewFetcher.data.error}</Body>
             </PreviewBox>


### PR DESCRIPTION
Added a handling for non conforming responses by the preview generator. If any errors occur there should be a json returned containing a field 'error' this isn't the case if the preview fails. In that case the string with the HTML is returned resulting in a crash. So this fix checks if the field 'error' exists or the type is 'string'. Second case the content will be simply be displayed.

It should be the case that a conceise error message is shown.