### PR TITLE
76 - Added ellipsis in column and line-break in the InfoPanel

### DIFF
--- a/app/components/Column.tsx
+++ b/app/components/Column.tsx
@@ -27,7 +27,7 @@ function ColumnElement(column: ColumnProps) {
     >
       <div className="flex items-center text-slate-800 bg-slate-50 mb-[3px] p-2 pb-0 transition dark:bg-slate-900 dark:text-slate-300">
         {column.icon && <column.icon className="h-6 w-6 mr-1" />}
-        <Title className="">{title}</Title>
+        <Title className="text-ellipsis overflow-hidden">{title}</Title>
       </div>
       <div
         className={`overflow-y-auto ${

--- a/app/components/InfoHeader.tsx
+++ b/app/components/InfoHeader.tsx
@@ -6,11 +6,11 @@ import { useJsonColumnViewState } from "~/hooks/useJsonColumnView";
 import { concatenated, getHierarchicalTypes } from "~/utilities/dataType";
 import { formatRawValue } from "~/utilities/formatter";
 import { isNullable } from "~/utilities/nullable";
+import { CopyTextButton } from "./CopyTextButton";
 import { Body } from "./Primitives/Body";
 import { LargeMono } from "./Primitives/LargeMono";
 import { Title } from "./Primitives/Title";
 import { ValueIcon, ValueIconSize } from "./ValueIcon";
-import { CopyTextButton } from "./CopyTextButton";
 
 export type InfoHeaderProps = {
   relatedPaths: string[];
@@ -41,12 +41,13 @@ export function InfoHeader({ relatedPaths }: InfoHeaderProps) {
   }, [relatedPaths, json]);
 
   const [hovering, setHovering] = useState(false);
+  console.warn(selectedInfo);
 
   return (
     <div className="mb-4 pb-4">
       <div className="flex items-center">
-        <Title className="flex-1 mr-2 text-slate-700 transition dark:text-slate-200">
-          {selectedName ?? "nothing"}
+        <Title className="flex-1 mr-2 overflow-hidden overflow-ellipsis break-words text-slate-700 transition dark:text-slate-200">
+          { selectedName ?? "nothing" }
         </Title>
         <div>
           <ValueIcon


### PR DESCRIPTION
Changed the columns header behaviour to make "..." if the name is too long, to leave it in one row.

![grafik](https://user-images.githubusercontent.com/6839449/172951458-883d37d0-4c20-4d7b-9cbe-0a44490f0ca9.png)

Added line breaking behaviour if the text is too long on the right side panel where the detailed information is shown. 

![grafik](https://user-images.githubusercontent.com/6839449/172951501-fa8199d5-8b28-45a7-924b-07b7588abd1e.png)

This behaviour was missing on the title before and therefore leading to horizontal scrolling by marking with the cursor  (no scrollbar was shown anyways).